### PR TITLE
TR-74 작성 폼 입력란 높이 조정, 작성 조건 추가, 수정 기능 추가, 타이틀을 'Q&A 게시판'으로 수정

### DIFF
--- a/src/views/member/service/QnAWriteView.vue
+++ b/src/views/member/service/QnAWriteView.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="home">
-    <QnAWrite :title="title" :submitLink="submitLink" :cancelLink="cancelLink" :detailLink="detailLink"/>
+    <QnAWrite :title="title" :detailURL="detailURL"
+      :submitLink="submitLink" :cancelLink="cancelLink" :detailLink="detailLink" :updateLink="updateLink"/>
   </div>
 </template>
 
@@ -15,10 +16,12 @@ export default {
   },
   data() {
     return {
-      title: "이곳에 타이틀 입력",
+      title: "Q&A 게시글 작성",
       submitLink: "http://localhost:8082/triplus/api/service/qna/write",
+      updateLink: "http://localhost:8082/triplus/api/service/qna/update",
       cancelLink: "/service/qna",
-      detailLink: "/service/qna/detail",
+      detailLink: "http://localhost:8082/triplus/api/service/qna/detail",
+      detailURL: "/service/qna/detail",
     };
   }
 }


### PR DESCRIPTION
입력에 대한 피드백(붉은 문장)이 제공될 때 폼의 크기가 일정하게 유지되지 않던 것을 개선

작성 페이지에 다음과 같은 작성 조건을 추가했으며, 조건에 맞지 않을 경우 게시글 작성이 불가능하도록 함
 제목: 4~30자
 이메일: xxx@xxxx (정규식)
 비밀번호: 4~20자
 문의 유형: 반드시 선택
 내용: 0자 이상

수정 기능은 작성 기능에 살을 덧붙이는 방식으로 추가
 상세보기 페이지에서 로컬 스토리지에 게시글번호와 비밀번호를 임시 저장
 이후 작성 페이지로 이동
 작성 페이지에서 로컬 스토리지에 저장된 게시글번호와 비밀번호를 조회, 만약 있을 경우 수정 모드로 진입
 수정 모드로 진입하며 서버에서 게시글 정보를 취득, 이후 작성 폼에 그대로 복사
 이후 수정 버튼을 눌러 같은 번호의 게시글 정보를 수정